### PR TITLE
Fixed Charge-spam bug causing the player to float 

### DIFF
--- a/src/player/src/state_machine/player_states/charge_falling.gd
+++ b/src/player/src/state_machine/player_states/charge_falling.gd
@@ -23,7 +23,6 @@ func enter(msg: Dictionary = {}):
 	audio_player = _actor.audio_player
 	#
 	_parent.enter()
-	_parent.velocity.y = 0
 	_parent.max_speed = max_speed
 	_parent.move_speed = move_speed
 	_parent.jump_impulse = jump_impulse

--- a/src/player/src/state_machine/player_states/falling.gd
+++ b/src/player/src/state_machine/player_states/falling.gd
@@ -19,7 +19,6 @@ func enter(msg: Dictionary = {}):
 	audio_player = _actor.audio_player
 	#
 	_parent.enter()
-	_parent.velocity.y = 0
 	_parent.max_speed = max_speed
 	_parent.move_speed = move_speed
 	_parent.jump_impulse = jump_impulse


### PR DESCRIPTION
Resetting `velocity.y` on `_enter()` call for `Falling` and `ChargeFalling` states was causing the issue, removing this fixes the issue.